### PR TITLE
FIX : replace the obsolete github repo in the deploy workflow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 mkdocs
 mkdocs-material
 markdown-include
-git+https://github.com/Mandy91/mkdocs-toc-sidebar-plugin.git@drop_python_2.7_support#egg=mkdocs-toc-sidebar-plugin
+git+https://github.com/zachhannum/mkdocs-toc-sidebar-plugin.git@drop_python_2.7_support#egg=mkdocs-toc-sidebar-plugin


### PR DESCRIPTION
fix : replace the obsolete github repo with a repo with the same name but under another github username.

Closes #3 